### PR TITLE
Add support for new schema used by pnpm 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantco/pnpm-licenses",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Generate third party license disclaimers in pnpm-based projects",
   "homepage": "https://github.com/Quantco/pnpm-licenses",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -83,6 +83,8 @@ type Dependency = {
 }
 ```
 
+> Note that if multiple versions of a package are installed the output will contain the same package multiple times with differing versions (and paths)
+
 ### Options
 
 ```

--- a/src/get-license-text.ts
+++ b/src/get-license-text.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import licenseTexts from 'spdx-license-list/full.js'
 import stripIndent from 'strip-indent'
 import removeMarkdown from 'remove-markdown'
-import type { PnpmDependency } from './get-dependencies'
+import type { PnpmDependencyFlattened } from './get-dependencies'
 
 const LICENSE_BASENAMES = [/* eslint-disable prettier/prettier */
   /^LICENSE$/i,           // e.g. LICENSE
@@ -36,7 +36,7 @@ const LICENSE_TEXT_SUBSTRINGS = {
 }
 
 export class MissingLicenseError extends Error {
-  constructor(public dependency: PnpmDependency) {
+  constructor(public dependency: PnpmDependencyFlattened) {
     super('No license text found for dependency ' + dependency.name)
   }
 }
@@ -50,14 +50,14 @@ const prettifyLicenseText = (licenseText: string) => {
   return stripIndent(removeMarkdown(licenseText)).trim()
 }
 
-export type PnpmDependencyResolvedLicenseText = PnpmDependency & {
+export type PnpmDependencyResolvedLicenseText = PnpmDependencyFlattened & {
   licenseText: string
   additionalText?: string
   resolvedBy: (typeof resolvedByTypes)[number]
 }
 
 export const getLicenseText = async (
-  dependency: PnpmDependency
+  dependency: PnpmDependencyFlattened
 ): Promise<{ licenseText: string; additionalText?: string; resolvedBy: (typeof resolvedByTypes)[number] }> => {
   const files = await fs.readdir(dependency.path)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises'
 import multimatch from 'multimatch'
 import { getDependencies } from './get-dependencies'
-import type { PnpmDependency } from './get-dependencies'
+import type { PnpmDependencyFlattened } from './get-dependencies'
 import { generateDisclaimer } from './generate-disclaimer'
 import { resolveLicensesBestEffort } from './resolve-licenses-best-effort'
 
@@ -31,10 +31,9 @@ const output = (value: string, options: IOOptions) => {
 }
 
 export const listCommand = async (options: ListOptions, ioOptions: IOOptions) => {
-  const deps = getDependencies(options, ioOptions)
-    .then(Object.values)
-    .then((deps: PnpmDependency[][]) => deps.flat())
-    .then((deps: PnpmDependency[]) => deps.filter((dep) => multimatch(dep.name, options.filters).length === 0))
+  const deps = getDependencies(options, ioOptions).then((deps: PnpmDependencyFlattened[]) =>
+    deps.filter((dep) => multimatch(dep.name, options.filters).length === 0)
+  )
 
   const { successful, failed } = await resolveLicensesBestEffort(await deps)
 
@@ -43,10 +42,9 @@ export const listCommand = async (options: ListOptions, ioOptions: IOOptions) =>
 }
 
 export const generateDisclaimerCommand = async (options: GenerateDisclaimerOptions, ioOptions: IOOptions) => {
-  const deps = getDependencies(options, ioOptions)
-    .then(Object.values)
-    .then((deps: PnpmDependency[][]) => deps.flat())
-    .then((deps: PnpmDependency[]) => deps.filter((dep) => multimatch(dep.name, options.filters).length === 0))
+  const deps = getDependencies(options, ioOptions).then((deps: PnpmDependencyFlattened[]) =>
+    deps.filter((dep) => multimatch(dep.name, options.filters).length === 0)
+  )
 
   const { successful, failed } = await resolveLicensesBestEffort(await deps)
 

--- a/src/resolve-licenses-best-effort.ts
+++ b/src/resolve-licenses-best-effort.ts
@@ -1,16 +1,16 @@
-import type { PnpmDependency } from './get-dependencies'
+import type { PnpmDependencyFlattened } from './get-dependencies'
 import { getLicenseText } from './get-license-text'
 import type { PnpmDependencyResolvedLicenseText } from './get-license-text'
 
 export const resolveLicensesBestEffort = async (
-  deps: PnpmDependency[]
-): Promise<{ successful: PnpmDependencyResolvedLicenseText[]; failed: PnpmDependency[] }> => {
+  deps: PnpmDependencyFlattened[]
+): Promise<{ successful: PnpmDependencyResolvedLicenseText[]; failed: PnpmDependencyFlattened[] }> => {
   const depsWithLicensesPromise = deps.map(async (dep) => ({ ...dep, ...(await getLicenseText(dep)) }))
 
   // keep track of which licenses could be resolved and which couldn't
   // include the index to restore the original order afterwards
   const successful: [number, PnpmDependencyResolvedLicenseText][] = []
-  const failed: [number, PnpmDependency][] = []
+  const failed: [number, PnpmDependencyFlattened][] = []
 
   await Promise.all(
     depsWithLicensesPromise.map((depPromise, index) =>


### PR DESCRIPTION
Both the old and new schema are supported at the same time.
This updates `getDependencies()` which is exposed via the "api"; thus a major version bump.