### PR TITLE
Fix `types` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "readme.md"
   ],
   "main": "dist/api.mjs",
-  "types": "dist/api.d.ts",
+  "types": "dist/api.d.mts",
   "bin": {
     "pnpm-licenses": "dist/index.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quantco/pnpm-licenses",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Generate third party license disclaimers in pnpm-based projects",
   "homepage": "https://github.com/Quantco/pnpm-licenses",
   "repository": {


### PR DESCRIPTION
The package was publishing `.d.mts` declaration files while the types field still referenced `.d.ts`. Update the path to match the actual generated output.

(This may have been introduced by a recent tsup upgrade.)